### PR TITLE
Audit Trail Wallet Smart Contract

### DIFF
--- a/zugo_contract/Clarinet.toml
+++ b/zugo_contract/Clarinet.toml
@@ -15,6 +15,11 @@ path = 'contracts/archive_with_reset_option.clar'
 clarity_version = 2
 epoch = 2.5
 
+[contracts.audit_trail_wallet]
+path = 'contracts/audit_trail_wallet.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.data_marketplace]
 path = 'contracts/data_marketplace.clar'
 clarity_version = 2

--- a/zugo_contract/contracts/audit_trail_wallet.clar
+++ b/zugo_contract/contracts/audit_trail_wallet.clar
@@ -197,3 +197,18 @@
     )
 )
 
+;; Get total contract statistics
+(define-read-only (get-contract-stats)
+    {
+        total-transactions: (- (var-get next-transaction-id) u1),
+        contract-balance: (stx-get-balance (as-contract tx-sender))
+    }
+)
+
+;; Admin function to get any user's balance (owner only)
+(define-read-only (admin-get-balance (user principal))
+    (begin
+        (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+        (ok (get-balance-internal user))
+    )
+)

--- a/zugo_contract/contracts/audit_trail_wallet.clar
+++ b/zugo_contract/contracts/audit_trail_wallet.clar
@@ -1,0 +1,199 @@
+;; Audit Trail Wallet Smart Contract
+;; Maintains full history of all deposits and withdrawals with comprehensive audit trail
+
+;; Constants
+(define-constant contract-owner tx-sender)
+(define-constant err-owner-only (err u100))
+(define-constant err-insufficient-balance (err u101))
+(define-constant err-invalid-amount (err u102))
+(define-constant err-invalid-user (err u103))
+
+;; Data Variables
+(define-data-var next-transaction-id uint u1)
+
+;; Data Maps
+;; User balances
+(define-map user-balances principal uint)
+
+;; Transaction history - stores all deposit/withdrawal records
+(define-map transaction-history 
+    uint 
+    {
+        user: principal,
+        transaction-type: (string-ascii 10), ;; "deposit" or "withdrawal"
+        amount: uint,
+        timestamp: uint, ;; burn-block-height when transaction occurred
+        block-height: uint, ;; same as timestamp for consistency
+        balance-after: uint
+    }
+)
+
+;; User transaction indexes - maps user to list of their transaction IDs
+(define-map user-transaction-ids principal (list 1000 uint))
+
+;; Total transaction count per user
+(define-map user-transaction-count principal uint)
+
+;; Private Functions
+
+;; Get current balance for a user
+(define-private (get-balance-internal (user principal))
+    (default-to u0 (map-get? user-balances user))
+)
+
+;; Update user balance
+(define-private (set-balance (user principal) (new-balance uint))
+    (map-set user-balances user new-balance)
+)
+
+;; Add transaction ID to user's transaction list
+(define-private (add-transaction-to-user (user principal) (tx-id uint))
+    (let ((current-list (default-to (list) (map-get? user-transaction-ids user))))
+        (map-set user-transaction-ids user (unwrap-panic (as-max-len? (append current-list tx-id) u1000)))
+    )
+)
+
+;; Increment user transaction count
+(define-private (increment-user-tx-count (user principal))
+    (let ((current-count (default-to u0 (map-get? user-transaction-count user))))
+        (map-set user-transaction-count user (+ current-count u1))
+    )
+)
+
+;; Record a transaction in the audit trail
+(define-private (record-transaction (user principal) (tx-type (string-ascii 10)) (amount uint) (balance-after uint))
+    (let ((tx-id (var-get next-transaction-id)))
+        ;; Store transaction details
+        (map-set transaction-history tx-id {
+            user: user,
+            transaction-type: tx-type,
+            amount: amount,
+            timestamp: burn-block-height,
+            block-height: burn-block-height,
+            balance-after: balance-after
+        })
+        ;; Add to user's transaction list
+        (add-transaction-to-user user tx-id)
+        ;; Increment counters
+        (increment-user-tx-count user)
+        (var-set next-transaction-id (+ tx-id u1))
+        tx-id
+    )
+)
+
+;; Public Functions
+
+;; Deposit STX to user's wallet
+(define-public (deposit (amount uint))
+    (begin
+        (asserts! (> amount u0) err-invalid-amount)
+        (let ((user tx-sender)
+              (current-balance (get-balance-internal tx-sender)))
+            (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+            (let ((new-balance (+ current-balance amount)))
+                (set-balance user new-balance)
+                (record-transaction user "deposit" amount new-balance)
+                (ok new-balance)
+            )
+        )
+    )
+)
+
+;; Withdraw STX from user's wallet
+(define-public (withdraw (amount uint))
+    (begin
+        (asserts! (> amount u0) err-invalid-amount)
+        (let ((user tx-sender)
+              (current-balance (get-balance-internal tx-sender)))
+            (asserts! (>= current-balance amount) err-insufficient-balance)
+            (try! (as-contract (stx-transfer? amount tx-sender user)))
+            (let ((new-balance (- current-balance amount)))
+                (set-balance user new-balance)
+                (record-transaction user "withdrawal" amount new-balance)
+                (ok new-balance)
+            )
+        )
+    )
+)
+
+;; Read-only Functions
+
+;; Get user's current balance
+(define-read-only (get-balance (user principal))
+    (get-balance-internal user)
+)
+
+;; Get specific transaction details by ID
+(define-read-only (get-transaction (tx-id uint))
+    (map-get? transaction-history tx-id)
+)
+
+;; Get user's transaction IDs list
+(define-read-only (get-user-transaction-ids (user principal))
+    (default-to (list) (map-get? user-transaction-ids user))
+)
+
+;; Get user's total transaction count
+(define-read-only (get-user-transaction-count (user principal))
+    (default-to u0 (map-get? user-transaction-count user))
+)
+
+;; Get user's recent transactions (last N transactions)
+(define-read-only (get-recent-transactions (user principal) (limit uint))
+    (let ((tx-ids (get-user-transaction-ids user))
+          (tx-count (len tx-ids)))
+        (if (> tx-count limit)
+            ;; Return last 'limit' transactions
+            (let ((start-index (- tx-count limit)))
+                (slice? tx-ids start-index tx-count)
+            )
+            ;; Return all transactions if count <= limit
+            (some tx-ids)
+        )
+    )
+)
+
+;; Get transaction details for a list of transaction IDs
+(define-read-only (get-transactions-batch (tx-ids (list 100 uint)))
+    (map get-transaction tx-ids)
+)
+
+;; Get user's transaction history with pagination
+(define-read-only (get-user-transactions-paginated (user principal) (offset uint) (limit uint))
+    (let ((tx-ids (get-user-transaction-ids user))
+          (tx-count (len tx-ids)))
+        (if (< offset tx-count)
+            (let ((end-index (if (> (+ offset limit) tx-count) tx-count (+ offset limit))))
+                (slice? tx-ids offset end-index)
+            )
+            none
+        )
+    )
+)
+
+;; Get user's deposit history only
+(define-read-only (get-user-deposits (user principal))
+    (filter is-deposit (map get-transaction (get-user-transaction-ids user)))
+)
+
+;; Get user's withdrawal history only
+(define-read-only (get-user-withdrawals (user principal))
+    (filter is-withdrawal (map get-transaction (get-user-transaction-ids user)))
+)
+
+;; Helper function to check if transaction is a deposit
+(define-read-only (is-deposit (tx (optional {user: principal, transaction-type: (string-ascii 10), amount: uint, timestamp: uint, block-height: uint, balance-after: uint})))
+    (match tx
+        some-tx (is-eq (get transaction-type some-tx) "deposit")
+        false
+    )
+)
+
+;; Helper function to check if transaction is a withdrawal
+(define-read-only (is-withdrawal (tx (optional {user: principal, transaction-type: (string-ascii 10), amount: uint, timestamp: uint, block-height: uint, balance-after: uint})))
+    (match tx
+        some-tx (is-eq (get transaction-type some-tx) "withdrawal")
+        false
+    )
+)
+

--- a/zugo_contract/tests/audit_trail_wallet.test.ts
+++ b/zugo_contract/tests/audit_trail_wallet.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
# Audit Trail Wallet — README

A Clarity smart contract that maintains user balances and a complete, queryable audit trail of all deposits and withdrawals. Every movement of funds is recorded with a monotonically increasing transaction ID, amount, type, timestamp, and post-balance.

---

## Highlights

* **Full history**: Every deposit/withdrawal is written to `transaction-history` with a unique ID.
* **Per-user indexes**: Fast lookup of a user’s transaction IDs via `user-transaction-ids`.
* **Pagination & filters**: Read-only helpers for recent activity, paginated ranges, deposits-only, withdrawals-only, and batch fetch.
* **Deterministic timestamps**: Uses `burn-block-height` for stable on-chain timing.
* **Safety checks**: Amount validation, balance checks, and owner-only admin read functions.

---

## Contract Anatomy

### Constants & Errors

* `contract-owner`: deployer/owner (captured at first call as written).
* Errors:

  * `err-owner-only` → `(err u100)`
  * `err-insufficient-balance` → `(err u101)`
  * `err-invalid-amount` → `(err u102)`
  * `err-invalid-user` → `(err u103)` *(declared, not currently used)*

### Storage

* `next-transaction-id : uint` — starts at `u1`, increments on every recorded tx.
* `user-balances : {principal => uint}` — current STX balance tracked by contract for each user.
* `transaction-history : {uint => { user, transaction-type, amount, timestamp, block-height, balance-after }}` — immutable audit records.
* `user-transaction-ids : {principal => (list 1000 uint)}` — ordered list of a user’s transaction IDs (oldest→newest).
* `user-transaction-count : {principal => uint}` — running count per user.

> **Note:** The per-user transaction list is capped at **1000** entries by design (`as-max-len? u1000`). See **Limits** below for options.

### Internal Helpers (private)

* `get-balance-internal(user)` → `uint`
* `set-balance(user, new-balance)`
* `add-transaction-to-user(user, tx-id)`
* `increment-user-tx-count(user)`
* `record-transaction(user, tx-type, amount, balance-after)` → `uint` (returns new `tx-id`)

---

## Public Interface

### Mutable entrypoints

#### `deposit(amount: uint) -> (response uint uint)`

Transfers `amount` STX **from caller to contract**, updates caller’s tracked balance, records a `"deposit"` transaction, and returns the new balance.

* Fails with:

  * `err-invalid-amount` if `amount <= u0`
  * Underlying `stx-transfer?` error if transfer fails

#### `withdraw(amount: uint) -> (response uint uint)`

Transfers `amount` STX **from contract to caller** (executes transfer in contract context), updates balance, records a `"withdrawal"` transaction, and returns the new balance.

* Fails with:

  * `err-invalid-amount` if `amount <= u0`
  * `err-insufficient-balance` if user balance < `amount`
  * Underlying `stx-transfer?` error if transfer fails

### Read-only queries

* `get-balance(user: principal) -> uint`
  Current tracked balance.

* `get-transaction(tx-id: uint) -> (optional { ... })`
  Fetch a single audit record.

* `get-user-transaction-ids(user: principal) -> (list 1000 uint)`
  Full ordered list of the user’s tx IDs (may be shorter than 1000).

* `get-user-transaction-count(user: principal) -> uint`
  Count of recorded transactions for the user.

* `get-recent-transactions(user: principal, limit: uint) -> (optional (list 1000 uint))`
  Returns last `limit` tx IDs if available, else returns all tx IDs (wrapped in `some`). Returns `none` only via the internal `slice?` semantics when out of range.

* `get-transactions-batch(tx-ids: (list 100 uint)) -> (list 100 (optional { ... }))`
  Vectorized fetch of many transactions by ID.

* `get-user-transactions-paginated(user: principal, offset: uint, limit: uint) -> (optional (list 1000 uint))`
  Returns a slice of the user’s tx IDs `[offset, offset+limit)` or `none` if `offset >= len`.

* `get-user-deposits(user: principal) -> (list 1000 (optional { ... }))`
  All deposit records for user (maps, then filters via `is-deposit`).

* `get-user-withdrawals(user: principal) -> (list 1000 (optional { ... }))`
  All withdrawal records for user.

* `get-contract-stats() -> { total-transactions: uint, contract-balance: uint }`
  Aggregate count (derived from `next-transaction-id`) and the on-chain STX balance held by the contract principal.

### Admin

* `admin-get-balance(user: principal) -> (response uint (tuple))`
  Owner-only getter for a user’s tracked balance.

---

## Data Model: Transaction Record

Each entry in `transaction-history`:

```clarity
{
  user: principal,
  transaction-type: (string-ascii 10),  ;; "deposit" | "withdrawal"
  amount: uint,
  timestamp: uint,                      ;; burn-block-height at record time
  block-height: uint,                   ;; same as timestamp (explicit)
  balance-after: uint                   ;; user's balance after this tx
}
```

---

## Usage Examples

> The snippets below illustrate intent; adapt to your test framework (Clarinet console, unit tests, or directly via clients).

### Deposit 100 STX (as user)

```clarity
(contract-call? .audit-trail-wallet deposit u100000000) ;; amount in micro-STX
```

### Withdraw 25 STX (as same user)

```clarity
(contract-call? .audit-trail-wallet withdraw u25000000)
```

### Query balance & latest activity

```clarity
;; Current balance
(clarity:call-read-only .audit-trail-wallet get-balance tx-sender)

;; Recent 5 transaction IDs
(clarity:call-read-only .audit-trail-wallet get-recent-transactions tx-sender u5)

;; Batch fetch details (replace with IDs you received)
(clarity:call-read-only .audit-trail-wallet get-transactions-batch (list u7 u8 u9 u10 u11))
```

### Paginate a user’s history

```clarity
;; First page (offset 0, limit 50)
(clarity:call-read-only .audit-trail-wallet get-user-transactions-paginated tx-sender u0 u50)

;; Next page (offset 50, limit 50)
(clarity:call-read-only .audit-trail-wallet get-user-transactions-paginated tx-sender u50 u50)
```

### Filtered views

```clarity
(clarity:call-read-only .audit-trail-wallet get-user-deposits tx-sender)
(clarity:call-read-only .audit-trail-wallet get-user-withdrawals tx-sender)
```

### Contract stats

```clarity
(clarity:call-read-only .audit-trail-wallet get-contract-stats)
```

---

## Design Notes & Limits

* **User tx list capacity**: `user-transaction-ids` is capped at **1000** items. If a user exceeds this, `append` will fail.

  * *Options*: Increase the max length, shard by pages (e.g., map of page index → list 1000), or derive views from `transaction-history` (global) instead of a single per-user list.
* **String length**: `transaction-type` uses `(string-ascii 10)` and fits `"withdrawal"` (10 chars) and `"deposit"`.
* **Timestamps**: Uses `burn-block-height` for deterministic timing (mirrored into `block-height` for explicitness).
* **Balances**: `user-balances` is the contract’s internal ledger; the **actual STX** sits in the contract account. Always ensure contract balance ≥ sum of user balances (see **Safety**).

---

## Safety & Operational Considerations

* **Invariant**: Over time, the sum of all tracked user balances should not exceed the actual `stx-get-balance` of the contract. If you plan to add fees or owner withdrawals, make sure you also record those events and adjust balances accordingly.
* **Reentrancy**: Clarity is non-reentrant and non-Turing complete; however, always handle transfer results via `try!`/`asserts!` as done here.
* **Owner privileges**: The only privileged read is `admin-get-balance`. There are no write-privileged admin functions (e.g., forced adjustments) in this version.
* **Error handling**: The contract aborts on invalid amounts and insufficient balances; client UIs should surface error codes (`u100–u103`).

---

## Testing Checklist

* Deposit/withdraw happy paths; verify `balance-after` and contract STX balance change.
* Reject zero/negative (i.e., `u0`) amounts.
* Withdraw fails when `amount > balance`.
* `transaction-history` increments IDs strictly (`u1, u2, ...`) and records accurate `timestamp`.
* Pagination boundaries (offset at end, offset+limit > len).
* `get-user-deposits` / `get-user-withdrawals` filter correctly.
* Capacity edge for `user-transaction-ids` when approaching 1000.

---

## Deployment & Integration

1. **Compile & test**: Use Clarinet to lint and run unit tests.
2. **Deploy**: Publish the contract to your target chain (testnet/mainnet).
3. **Fund the contract**: Users deposit via `deposit`; contract’s principal must hold enough STX to fulfill withdrawals.
4. **Indexing** (optional): For large-scale analytics, mirror `transaction-history` off-chain for richer queries and CSV exports.

---

## Future Extensions

* Event emitters (via print logs) for external indexers.
* Fee mechanics (recorded as their own tx type).
* Owner/admin adjustments (credit/debit with audit records).
* Sharded/per-page transaction indices to lift the 1000-entry cap.
* SIP-010 token support for fungible tokens in addition to STX.

---

## License

Add your preferred license (e.g., MIT/Apache-2.0) here.

---